### PR TITLE
Add server_name to nginx.conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -60,11 +60,10 @@ http {
     }
 
     server {
+        server_name localhost
         listen unix:/var/run/mysql-resurrection.sock;
         location / {
             proxy_intercept_errors on;
-
-
             proxy_set_header Host $host;
             error_page 418 = @backtophp;
             proxy_pass http://10.128.0.203:452;


### PR DESCRIPTION
Adds a `server_name` to get XDebug working with PHPStorm.